### PR TITLE
Feature/cloudify 2416 integrate packager

### DIFF
--- a/cloudify_openstack/cloudify-config.defaults.yaml
+++ b/cloudify_openstack/cloudify-config.defaults.yaml
@@ -60,9 +60,10 @@ compute:
 
 cloudify:
     cloudify_branch: develop
-    cloudify_components_package_url: https://s3-us-west-1.amazonaws.com/gigaspaces-cosmo-packages/cloudify3-components_3.0.0_amd64.deb
-    cloudify_package_url: https://s3-us-west-1.amazonaws.com/gigaspaces-cosmo-packages/cloudify3_3.0.0_amd64.deb
+    #cloudify_components_package_url: https://s3-us-west-1.amazonaws.com/gigaspaces-cosmo-packages/cloudify3-components_3.0.0_amd64.deb
+    cloudify_components_package_url: https://dl.dropboxusercontent.com/u/407576/cloudify3-components_3.0.0_amd64.deb
+    #cloudify_package_url: https://s3-us-west-1.amazonaws.com/gigaspaces-cosmo-packages/cloudify3_3.0.0_amd64.deb
+    cloudify_package_url: https://dl.dropboxusercontent.com/u/407576/cloudify3_3.0.0_amd64.deb
     cloudify_packages_path: /cloudify
     cloudify_components_package_path: /cloudify3-components
     cloudify_package_path: /cloudify3
-    management_instance_user: ubuntu

--- a/cloudify_openstack/cloudify-config.defaults.yaml
+++ b/cloudify_openstack/cloudify-config.defaults.yaml
@@ -63,5 +63,6 @@ cloudify:
     cloudify_components_package_url: https://s3-us-west-1.amazonaws.com/gigaspaces-cosmo-packages/cloudify3-components_3.0.0_amd64.deb
     cloudify_package_url: https://s3-us-west-1.amazonaws.com/gigaspaces-cosmo-packages/cloudify3_3.0.0_amd64.deb
     cloudify_packages_path: /cloudify
-    cloudify_components_package_path: cloudify3-components
+    cloudify_components_package_path: /cloudify3-components
     cloudify_package_path: /cloudify3
+    management_instance_user: ubuntu

--- a/cloudify_openstack/cloudify-config.defaults.yaml
+++ b/cloudify_openstack/cloudify-config.defaults.yaml
@@ -60,3 +60,8 @@ compute:
 
 cloudify:
     cloudify_branch: develop
+    cloudify_components_package_url: https://s3-us-west-1.amazonaws.com/gigaspaces-cosmo-packages/cloudify3-components_3.0.0_amd64.deb
+    cloudify_package_url: https://s3-us-west-1.amazonaws.com/gigaspaces-cosmo-packages/cloudify3_3.0.0_amd64.deb
+    cloudify_packages_path: /cloudify
+    cloudify_components_package_path: cloudify3-components
+    cloudify_package_path: /cloudify3

--- a/cloudify_openstack/cloudify-config.yaml
+++ b/cloudify_openstack/cloudify-config.yaml
@@ -61,8 +61,9 @@ keystone:
 #cloudify:
 #    cloudify_branch: develop
 #    cloudify_components_package_url: https://s3-us-west-1.amazonaws.com/gigaspaces-cosmo-packages/cloudify3-components_3.0.0_amd64.deb
+#    cloudify_components_package_url: https://dl.dropboxusercontent.com/u/407576/cloudify3-components_3.0.0_amd64.deb
 #    cloudify_package_url: https://s3-us-west-1.amazonaws.com/gigaspaces-cosmo-packages/cloudify3_3.0.0_amd64.deb
+#    cloudify_package_url: https://dl.dropboxusercontent.com/u/407576/cloudify3-components_3.0.0_amd64.deb
 #    cloudify_packages_path: /cloudify
 #    cloudify_components_package_path: /cloudify3-components
 #    cloudify_package_path: /cloudify3
-#	 management_instance_user: ubuntu

--- a/cloudify_openstack/cloudify-config.yaml
+++ b/cloudify_openstack/cloudify-config.yaml
@@ -63,5 +63,6 @@ keystone:
 #    cloudify_components_package_url: https://s3-us-west-1.amazonaws.com/gigaspaces-cosmo-packages/cloudify3-components_3.0.0_amd64.deb
 #    cloudify_package_url: https://s3-us-west-1.amazonaws.com/gigaspaces-cosmo-packages/cloudify3_3.0.0_amd64.deb
 #    cloudify_packages_path: /cloudify
-#    cloudify_components_package_path: cloudify3-components
+#    cloudify_components_package_path: /cloudify3-components
 #    cloudify_package_path: /cloudify3
+#	 management_instance_user: ubuntu

--- a/cloudify_openstack/cloudify-config.yaml
+++ b/cloudify_openstack/cloudify-config.yaml
@@ -60,3 +60,8 @@ keystone:
 #
 #cloudify:
 #    cloudify_branch: develop
+#    cloudify_components_package_url: https://s3-us-west-1.amazonaws.com/gigaspaces-cosmo-packages/cloudify3-components_3.0.0_amd64.deb
+#    cloudify_package_url: https://s3-us-west-1.amazonaws.com/gigaspaces-cosmo-packages/cloudify3_3.0.0_amd64.deb
+#    cloudify_packages_path: /cloudify
+#    cloudify_components_package_path: cloudify3-components
+#    cloudify_package_path: /cloudify3

--- a/cloudify_openstack/cloudify_openstack.py
+++ b/cloudify_openstack/cloudify_openstack.py
@@ -294,7 +294,7 @@ class CosmoOnOpenStackBootstrapper(object):
         return expanduser(path)
 
     def _download_package(self, url, path):
-        r = run('wget %s -P %s' % (path, url))
+        r = run('sudo wget %s -P %s' % (path, url))
         return r
 
     def _unpack(self, path):
@@ -323,7 +323,7 @@ class CosmoOnOpenStackBootstrapper(object):
                 management_server_config['management_keypair']),
             management_server_config['user_on_management'])
 
-        env.user = cosmo_config['management_instance_user']
+        env.user = management_server_config['user_on_management']
         env.warn_only = 0
         env.abort_on_prompts = False
         env.connection_attempts = 5
@@ -349,33 +349,21 @@ class CosmoOnOpenStackBootstrapper(object):
                 _output(logging.DEBUG, 'Downloading Cloudify Components Package...')
                 self._download_package(cosmo_config['cloudify_packages_path'],
                                        cosmo_config['cloudify_components_package_url'])
-            # self._exec_command_on_manager(ssh,
-                                          # 'sudo wget %s -P %s' %
-                                          # (cosmo_config['cloudify_components_package_url'],
-                                           # cosmo_config['cloudify_packages_path']))
+
                 _output(logging.DEBUG, 'Downloading Cloudify Package...')
                 self._download_package(cosmo_config['cloudify_packages_path'],
                                        cosmo_config['cloudify_package_url'])
-            # self._exec_command_on_manager(ssh,
-                                          # 'sudo wget %s -P %s' %
-                                          # (cosmo_config['cloudify_package_url'],
-                                           # cosmo_config['cloudify_packages_path']))
+
                 _output(logging.DEBUG, 'Unpacking Cloudify Packages...')
                 self._unpack(cosmo_config['cloudify_packages_path'])
-            # self._exec_command_on_manager(ssh,
-                                          # 'sudo dpkg -i %s/*.deb' %
-                                          # cosmo_config['cloudify_packages_path'])
 
+                _output(logging.DEBUG, 'Install Cloudify on Management Server...')
                 self._run('sudo %s/cloudify3-components-bootstrap.sh' %
                           cosmo_config['cloudify_components_package_path'])
-            # self._exec_command_on_manager(ssh,
-                                          # 'sudo %s/cloudify3-components-bootstrap.sh' %
-                                          # cosmo_config['cloudify_components_package_path'])
+
                 self._run('sudo %s/cloudify3-bootstrap.sh' %
                           cosmo_config['cloudify_package_path'])
-            # self._exec_command_on_manager(ssh,
-                                          # 'sudo %s/cloudify3-bootstrap.sh' %
-                                          # cosmo_config['cloudify_package_path'])
+
             #except:
             #    raise RuntimeError('Failed to install Cloudify on %s' % mgmt_ip)
         else:

--- a/cloudify_openstack/cloudify_openstack.py
+++ b/cloudify_openstack/cloudify_openstack.py
@@ -72,7 +72,8 @@ def init(target_directory, reset_config, is_verbose_output=False):
     return True
 
 
-def bootstrap(config_path=None, is_verbose_output=False, bootstrap_using_script=True):
+def bootstrap(config_path=None, is_verbose_output=False,
+              bootstrap_using_script=True):
     global verbose_output
     verbose_output = is_verbose_output
 
@@ -339,7 +340,8 @@ class CosmoOnOpenStackBootstrapper(object):
         env.timeout = 10
         env.forward_agent = True
         env.status = False
-        env.key_filename = [mgr_kpconf['auto_generated']['private_key_target_path']]
+        env.key_filename = [mgr_kpconf['auto_generated']
+                           ['private_key_target_path']]
 
         if not bootstrap_using_script:
             self._copy_files_to_manager(
@@ -351,18 +353,23 @@ class CosmoOnOpenStackBootstrapper(object):
 
             with settings(host_string=mgmt_ip), hide('running'):
 
-                _output(logging.DEBUG, 'Downloading Cloudify Components Package...')
-                self._download_package(cosmo_config['cloudify_packages_path'],
-                                       cosmo_config['cloudify_components_package_url'])
+                _output(logging.DEBUG, 'Downloading Cloudify'
+                                       ' Components Package...')
+                self._download_package(
+                    cosmo_config['cloudify_packages_path'],
+                    cosmo_config['cloudify_components_package_url'])
 
                 _output(logging.DEBUG, 'Downloading Cloudify Package...')
-                self._download_package(cosmo_config['cloudify_packages_path'],
-                                       cosmo_config['cloudify_package_url'])
+                self._download_package(
+                    cosmo_config['cloudify_packages_path'],
+                    cosmo_config['cloudify_package_url'])
 
                 _output(logging.DEBUG, 'Unpacking Cloudify Packages...')
-                self._unpack(cosmo_config['cloudify_packages_path'])
+                self._unpack(
+                    cosmo_config['cloudify_packages_path'])
 
-                _output(logging.DEBUG, 'Install Cloudify on Management Server...')
+                _output(logging.DEBUG, 'Install Cloudify on'
+                                       ' Management Server...')
                 self._run('sudo %s/cloudify3-components-bootstrap.sh' %
                           cosmo_config['cloudify_components_package_path'])
 
@@ -377,7 +384,8 @@ class CosmoOnOpenStackBootstrapper(object):
                     self._get_private_key_path_from_keypair_config(
                         compute_config['agent_servers']['agents_keypair']))
 
-                _output(logging.DEBUG, 'Installing required packages on manager')
+                _output(logging.DEBUG, 'Installing required packages'
+                                       ' on manager')
                 self._exec_command_on_manager(ssh, 'echo "127.0.0.1 '
                                                    '$(cat /etc/hostname)" | '
                                                    'sudo tee -a /etc/hosts')
@@ -409,10 +417,11 @@ class CosmoOnOpenStackBootstrapper(object):
                 _output(logging.DEBUG, 'cloning cosmo on manager')
                 self._exec_command_on_manager(ssh, 'mkdir -p {0}'
                     .format(workingdir))
-                self._exec_command_on_manager(ssh, 'git clone https://github.com/'
-                                                   'CloudifySource/cosmo-manager'
-                                                   '.git {0}/cosmo-manager'
-                                                   ' --depth 1'
+                self._exec_command_on_manager(ssh,
+                                              'git clone https://github.com/'
+                                              'CloudifySource/cosmo-manager'
+                                              '.git {0}/cosmo-manager'
+                                              ' --depth 1'
                     .format(workingdir))
                 self._exec_command_on_manager(ssh, '( cd {0}/cosmo-manager ; '
                                                    'git checkout {1} )'
@@ -420,10 +429,10 @@ class CosmoOnOpenStackBootstrapper(object):
 
                 _output(logging.DEBUG, 'running the manager bootstrap script '
                                        'remotely')
-                run_script_command = 'DEBIAN_FRONTEND=noninteractive python2.7 ' \
-                                     '{0}/cosmo-manager/vagrant/' \
-                                     'bootstrap_lxc_manager.py --working_dir=' \
-                                     '{0} --cosmo_version={1} ' \
+                run_script_command = 'DEBIAN_FRONTEND=noninteractive ' \
+                                     'python2.7 {0}/cosmo-manager/vagrant/' \
+                                     'bootstrap_lxc_manager.py ' \
+                                     '--working_dir={0} --cosmo_version={1} ' \
                                      '--config_dir={2} ' \
                                      '--install_openstack_provisioner ' \
                                      '--install_logstash' \

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,6 @@ setup(
         "python-keystoneclient",
         "python-neutronclient",
         "scp"
+        "fabric"
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "python-novaclient",
         "python-keystoneclient",
         "python-neutronclient",
-        "scp"
+        "scp",
         "fabric"
     ]
 )


### PR DESCRIPTION
Adds a bootstrap_using_script flag to install the manager on OpenStack using the script and defaults to a new installation section which installs the manager using the package.
