### PR TITLE
CLOUDIFY-2551 changed create_or_ensure_exists logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ In order to boostrap Cloudify manager on OpenStack you must edit the cloudify-co
 
 The following configuration options are available in the cloudify-config.defaults.yaml file. You can edit this file if you need to change any of these defaults:
 
+NOTE: the use_existing parameter follows this logic:
+* if a resource exists and use_existing is true, it will use the resource.
+* if a resource exists and use_existing is false, it will use the resource.
+* if a resource does not exist and use_existing is true, it will raise an exception.
+* if a resource does not exist and use_existing is false, it will create the resource.
+
 * Keystone configuration
 
   * auth_url: The URL to Keystone authentication service

--- a/cloudify_openstack/cloudify-config.defaults.yaml
+++ b/cloudify_openstack/cloudify-config.defaults.yaml
@@ -8,24 +8,24 @@ networking:
     neutron_supported_region: True
     neutron_url: https://region-b.geo-1.network.hpcloudsvc.com
     int_network:
-        externally_provisioned: False
+        use_existing: False
         name: cloudify-admin-network
     subnet:
-        externally_provisioned: False
+        use_existing: False
         name: cloudify-admin-network-subnet
         ip_version: 4
         cidr: 10.67.79.0/24
     ext_network:
-        externally_provisioned: True #For now, this must be 'externally_provisioned': 1
+        use_existing: True #For now, this must be 'use_existing': True
         name: Ext-Net
     router:
-        externally_provisioned: False
+        use_existing: False
         name: cloudify-router
     agents_security_group:
-            externally_provisioned: False
+            use_existing: False
             name: cloudify-sg-agents
     management_security_group:
-        externally_provisioned: False
+        use_existing: False
         name: cloudify-sg-management
         cidr: 0.0.0.0/0
 
@@ -36,12 +36,12 @@ compute:
         user_on_management: ubuntu
         userhome_on_management: /home/ubuntu
         instance:
-            externally_provisioned: False
+            use_existing: False
             name: cloudify-management-server
             image: 8c096c29-a666-4b82-99c4-c77dc70cfb40
             flavor: 102
         management_keypair:
-            externally_provisioned: False
+            use_existing: False
             name: cloudify-management-kp
             #provided:
                 #public_key_filepath: [PUBLIC-KEY-PATH]
@@ -50,7 +50,7 @@ compute:
                 private_key_target_path: ~/.ssh/cloudify-management-kp.pem
     agent_servers:
         agents_keypair:
-            externally_provisioned: False
+            use_existing: False
             name: cloudify-agents-kp
             #provided:
                 #public_key_filepath: [PUBLIC-KEY-PATH]

--- a/cloudify_openstack/cloudify-config.yaml
+++ b/cloudify_openstack/cloudify-config.yaml
@@ -8,24 +8,24 @@ keystone:
 #    neutron_supported_region: True
 #    neutron_url: https://region-b.geo-1.network.hpcloudsvc.com
 #    int_network:
-#        externally_provisioned: False
+#        use_existing: False
 #        name: cloudify-admin-network
 #    subnet:
-#        externally_provisioned: False
+#        use_existing: False
 #        name: cloudify-admin-network-subnet
 #        ip_version: 4
 #        cidr: 10.67.79.0/24
 #    ext_network:
-#        externally_provisioned: True #For now, this must be 'externally_provisioned': True
+#        use_existing: True #For now, this must be 'use_existing': True
 #        name: Ext-Net
 #    router:
-#        externally_provisioned: False
+#        use_existing: False
 #        name: cloudify-router
 #    agents_security_group:
-#            externally_provisioned: False
+#            use_existing: False
 #            name: cloudify-sg-agents
 #    management_security_group:
-#        externally_provisioned: False
+#        use_existing: False
 #        name: cloudify-sg-management
 #        cidr: 0.0.0.0/0
 #
@@ -36,12 +36,12 @@ keystone:
 #        user_on_management: ubuntu
 #        userhome_on_management: /home/ubuntu
 #        instance:
-#            externally_provisioned: False
+#            use_existing: False
 #            name: cloudify-management-server
 #            image: 8c096c29-a666-4b82-99c4-c77dc70cfb40
 #            flavor: 102
 #        management_keypair:
-#            externally_provisioned: False
+#            use_existing: False
 #            name: cloudify-management-kp
 #            #provided:
 #                #public_key_filepath: [PUBLIC-KEY-PATH]
@@ -50,7 +50,7 @@ keystone:
 #                private_key_target_path: ~/.ssh/cloudify-management-kp.pem
 #    agent_servers:
 #        agents_keypair:
-#            externally_provisioned: False
+#            use_existing: False
 #            name: cloudify-agents-kp
 #            #provided:
 #                #public_key_filepath: [PUBLIC-KEY-PATH]

--- a/cloudify_openstack/cloudify_openstack.py
+++ b/cloudify_openstack/cloudify_openstack.py
@@ -49,7 +49,7 @@ import novaclient.v1_1.client as nova_client
 import neutronclient.neutron.client as neutron_client
 
 
-EP_FLAG = 'externally_provisioned'
+EP_FLAG = 'use_existing'
 
 EXTERNAL_PORTS = (22, 8100)  # SSH, REST service
 INTERNAL_PORTS = (5555, 5672, 53229)  # Riemann, RabbitMQ, FileServer
@@ -727,19 +727,19 @@ class CreateOrEnsureExists(object):
                 raise already exists
             use resource
         else:
-            if externally provisioned:
-                raise marked as externally provisioned but does not exist
-            create create
+            if use_existing:
+                raise is configured to use_existing but does not exist
+            create resource
         """
         if self._check(name, *args, **kw):
-            if self.__class__.WHAT == 'server':
+            if self.__class__.WHAT in ('server'):
                 raise OpenStackLogicError("{0} '{1}' already exists".format(
                                           self.__class__.WHAT, name))
             return self.ensure_exists(name, *args, **kw)
         else:
             if EP_FLAG in provider_config and provider_config[EP_FLAG]:
-                raise OpenStackLogicError("{0} '{1}' is marked as externally "
-                                          "provisioned but does not exist"
+                raise OpenStackLogicError("{0} '{1}' is configured to 'use_"
+                                          "existing' but does not exist"
                                           .format(self.__class__.WHAT, name))
             return self._create(name, *args, **kw)
 

--- a/cloudify_openstack/cloudify_openstack.py
+++ b/cloudify_openstack/cloudify_openstack.py
@@ -703,21 +703,45 @@ class OpenStackLogicError(RuntimeError):
 
 class CreateOrEnsureExists(object):
 
-    def create_or_ensure_exists(self, provider_config, name, *args, **kw):
-        # config hash is only used for 'externally_provisioned' attribute
-        if EP_FLAG in provider_config and provider_config[EP_FLAG]:
-            method = 'ensure_exists'
-        else:
-            method = 'check_and_create'
-        return getattr(self, method)(name, *args, **kw)
-
-    def check_and_create(self, name, *args, **kw):
+    def _create(self, name, *args, **kw):
         lgr.debug("Will create {0} '{1}'".format(
             self.__class__.WHAT, name))
-        if self.list_objects_with_name(name):
-            raise OpenStackLogicError("{0} '{1}' already exists".format(
-                self.__class__.WHAT, name))
         return self.create(name, *args, **kw)
+
+    def _check(self, name, *args, **kw):
+        lgr.debug("Checking to see if {0} '{1}' already exists".format(
+            self.__class__.WHAT, name))
+        if self.list_objects_with_name(name):
+            lgr.debug("{0} '{1}' already exists".format(
+                self.__class__.WHAT, name))
+            return True
+        else:
+            lgr.debug("{0} '{1}' does not exist".format(
+                self.__class__.WHAT, name))
+            return False
+
+    def create_or_ensure_exists(self, provider_config, name, *args, **kw):
+        """
+        if resource exists:
+            if resource is server:
+                raise already exists
+            use resource
+        else:
+            if externally provisioned:
+                raise marked as externally provisioned but does not exist
+            create create
+        """
+        if self._check(name, *args, **kw):
+            if self.__class__.WHAT == 'server':
+                raise OpenStackLogicError("{0} '{1}' already exists".format(
+                                          self.__class__.WHAT, name))
+            return self.ensure_exists(name, *args, **kw)
+        else:
+            if EP_FLAG in provider_config and provider_config[EP_FLAG]:
+                raise OpenStackLogicError("{0} '{1}' is marked as externally "
+                                          "provisioned but does not exist"
+                                          .format(self.__class__.WHAT, name))
+            return self._create(name, *args, **kw)
 
     def ensure_exists(self, name, *args, **kw):
         lgr.debug("Will use existing {0} '{1}'"


### PR DESCRIPTION
from now on, if resources exist, they will be used (regardless of the EP field - unless it's a server and then an exception will be raised).
if resources don't exist, they will be created (unless EP field is true and then an exception will be raised).
